### PR TITLE
split out `StringRenderer` trait

### DIFF
--- a/tachydom/src/renderer/dom.rs
+++ b/tachydom/src/renderer/dom.rs
@@ -1,6 +1,6 @@
 #[cfg(any(feature = "tokio", feature = "web"))]
 use super::SpawningRenderer;
-use super::{CastFrom, DomRenderer, Renderer};
+use super::{CastFrom, DomRenderer, Renderer, StringRenderer};
 use crate::{
     dom::{document, window},
     ok_or_debug, or_debug,
@@ -71,27 +71,11 @@ impl Dom {
 
 impl Renderer for Dom {
     type Node = Node;
-    type Text = Text;
     type Element = Element;
     type Placeholder = Comment;
 
-    fn create_text_node(text: &str) -> Self::Text {
-        document().create_text_node(text)
-    }
-
     fn create_placeholder() -> Self::Placeholder {
         document().create_comment("")
-    }
-
-    fn set_text(node: &Self::Text, text: &str) {
-        /* PENDING.with(|p| {
-            let mut p = p.borrow_mut();
-            p.text.push_str(text);
-            let idx = add_node_to_heap(node);
-            p.nodes.push(idx);
-            p.lengths.push(text.len() as u32);
-        }); */
-        node.set_node_value(Some(text));
     }
 
     fn set_attribute(node: &Self::Element, name: &str, value: &str) {
@@ -147,6 +131,25 @@ impl Renderer for Dom {
 
     fn clear_children(parent: &Self::Element) {
         parent.set_text_content(Some(""));
+    }
+}
+
+impl StringRenderer for Dom {
+    type Text = Text;
+
+    fn create_text_node(text: &str) -> Self::Text {
+        document().create_text_node(text)
+    }
+
+    fn set_text(node: &Self::Text, text: &str) {
+        /* PENDING.with(|p| {
+            let mut p = p.borrow_mut();
+            p.text.push_str(text);
+            let idx = add_node_to_heap(node);
+            p.nodes.push(idx);
+            p.lengths.push(text.len() as u32);
+        }); */
+        node.set_node_value(Some(text));
     }
 }
 

--- a/tachydom/src/renderer/mock_dom.rs
+++ b/tachydom/src/renderer/mock_dom.rs
@@ -4,7 +4,7 @@
 //!
 //! Do not use this for anything real.
 
-use super::{CastFrom, DomRenderer, Renderer};
+use super::{CastFrom, DomRenderer, Renderer, StringRenderer};
 use crate::{
     html::element::{CreateElement, ElementType},
     view::Mountable,
@@ -373,24 +373,11 @@ impl<E: ElementType> CreateElement<MockDom> for E {
 
 impl Renderer for MockDom {
     type Node = Node;
-    type Text = Text;
     type Element = Element;
     type Placeholder = Placeholder;
 
-    fn create_text_node(data: &str) -> Self::Text {
-        document().create_text_node(data)
-    }
-
     fn create_placeholder() -> Self::Placeholder {
         document().create_placeholder()
-    }
-
-    fn set_text(node: &Self::Text, text: &str) {
-        Document::with_node_mut(node.0 .0, |node| {
-            if let NodeType::Text(ref mut node) = node.ty {
-                *node = text.to_string();
-            }
-        });
     }
 
     fn set_attribute(node: &Self::Element, name: &str, value: &str) {
@@ -535,6 +522,22 @@ impl Renderer for MockDom {
                 node.parent = None;
             });
         }
+    }
+}
+
+impl StringRenderer for MockDom {
+    type Text = Text;
+
+    fn create_text_node(data: &str) -> Self::Text {
+        document().create_text_node(data)
+    }
+
+    fn set_text(node: &Self::Text, text: &str) {
+        Document::with_node_mut(node.0 .0, |node| {
+            if let NodeType::Text(ref mut node) = node.ty {
+                *node = text.to_string();
+            }
+        });
     }
 }
 

--- a/tachydom/src/renderer/mod.rs
+++ b/tachydom/src/renderer/mod.rs
@@ -15,8 +15,6 @@ pub trait Renderer: Sized {
     type Node: Mountable<Self>;
     /// A visible element in the view tree.
     type Element: AsRef<Self::Node> + CastFrom<Self::Node> + Mountable<Self>;
-    /// A text node in the view tree.
-    type Text: AsRef<Self::Node> + CastFrom<Self::Node> + Mountable<Self>;
     /// A placeholder node, which can be inserted into the tree but does not
     /// appear (e.g., a comment node in the DOM).
     type Placeholder: AsRef<Self::Node>
@@ -29,14 +27,8 @@ pub trait Renderer: Sized {
         tag.create_element()
     }
 
-    /// Creates a new text node.
-    fn create_text_node(text: &str) -> Self::Text;
-
     /// Creates a new placeholder node.
     fn create_placeholder() -> Self::Placeholder;
-
-    /// Sets the text content of the node. If it's not a text node, this does nothing.
-    fn set_text(node: &Self::Text, text: &str);
 
     /// Sets the given attribute on the given node by key and value.
     fn set_attribute(node: &Self::Element, name: &str, value: &str);
@@ -89,6 +81,21 @@ pub trait Renderer: Sized {
     fn next_sibling(node: &Self::Node) -> Option<Self::Node>;
 
     fn log_node(node: &Self::Node);
+}
+
+/// A renderer that supports rendering strings as unstyled text nodes.
+///
+/// This is separated into its own trait because not all renderers support this, and
+/// in those cases should only use their own text widgets, not plain strings.
+pub trait StringRenderer: Renderer {
+    /// A text node in the view tree.
+    type Text: AsRef<Self::Node> + CastFrom<Self::Node> + Mountable<Self>;
+
+    /// Creates a new text node.
+    fn create_text_node(text: &str) -> Self::Text;
+
+    /// Sets the text content of the node.
+    fn set_text(node: &Self::Text, text: &str);
 }
 
 /// Additional rendering behavior that applies only to DOM nodes.

--- a/tachydom/src/view/primitives.rs
+++ b/tachydom/src/view/primitives.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::{
     hydration::Cursor,
-    renderer::{CastFrom, Renderer},
+    renderer::{CastFrom, Renderer, StringRenderer},
     view::ToTemplate,
 };
 use std::{
@@ -20,9 +20,9 @@ macro_rules! render_primitive {
   ($($child_type:ty),* $(,)?) => {
     $(
 		paste::paste! {
-			pub struct [<$child_type:camel State>]<R>(R::Text, $child_type) where R: Renderer;
+			pub struct [<$child_type:camel State>]<R>(R::Text, $child_type) where R: StringRenderer;
 
-			impl<'a, R: Renderer> Mountable<R> for [<$child_type:camel State>]<R> {
+			impl<'a, R: StringRenderer> Mountable<R> for [<$child_type:camel State>]<R> {
 					fn unmount(&mut self) {
 						self.0.unmount()
 					}
@@ -45,7 +45,7 @@ macro_rules! render_primitive {
 					}
 			}
 
-			impl<'a, R: Renderer> Render<R> for $child_type {
+			impl<'a, R: StringRenderer> Render<R> for $child_type {
 				type State = [<$child_type:camel State>]<R>;
 
 				fn build(self) -> Self::State {
@@ -66,7 +66,7 @@ macro_rules! render_primitive {
 
 			impl<'a, R> RenderHtml<R> for $child_type
 			where
-				R: Renderer,
+				R: StringRenderer,
 				R::Node: Clone,
 				R::Element: Clone,
 			{

--- a/tachydom/src/view/static_types.rs
+++ b/tachydom/src/view/static_types.rs
@@ -9,7 +9,7 @@ use crate::{
         style::IntoStyle,
     },
     hydration::Cursor,
-    renderer::{DomRenderer, Renderer},
+    renderer::{DomRenderer, Renderer, StringRenderer},
 };
 use std::marker::PhantomData;
 
@@ -109,7 +109,7 @@ impl<const V: &'static str> AsRef<str> for Static<V> {
     }
 }
 
-impl<const V: &'static str, R: Renderer> Render<R> for Static<V>
+impl<const V: &'static str, R: StringRenderer> Render<R> for Static<V>
 where
     R::Text: Mountable<R>,
 {
@@ -128,7 +128,7 @@ impl<const V: &'static str> InfallibleRender for Static<V> {}
 
 impl<const V: &'static str, R> RenderHtml<R> for Static<V>
 where
-    R: Renderer,
+    R: StringRenderer,
     R::Node: Clone,
     R::Element: Clone,
     R::Text: Mountable<R>,

--- a/tachydom/src/view/strings.rs
+++ b/tachydom/src/view/strings.rs
@@ -4,16 +4,16 @@ use super::{
 };
 use crate::{
     hydration::Cursor,
-    renderer::{CastFrom, Renderer},
+    renderer::{CastFrom, Renderer, StringRenderer},
 };
 use std::{rc::Rc, sync::Arc};
 
-pub struct StrState<'a, R: Renderer> {
+pub struct StrState<'a, R: StringRenderer> {
     pub node: R::Text,
     str: &'a str,
 }
 
-impl<'a, R: Renderer> Render<R> for &'a str {
+impl<'a, R: StringRenderer> Render<R> for &'a str {
     type State = StrState<'a, R>;
 
     fn build(self) -> Self::State {
@@ -34,7 +34,7 @@ impl<'a> InfallibleRender for &'a str {}
 
 impl<'a, R> RenderHtml<R> for &'a str
 where
-    R: Renderer,
+    R: StringRenderer,
     R::Node: Clone,
     R::Element: Clone,
 {
@@ -98,7 +98,7 @@ impl<'a> ToTemplate for &'a str {
 
 impl<'a, R> Mountable<R> for StrState<'a, R>
 where
-    R: Renderer,
+    R: StringRenderer,
 {
     fn unmount(&mut self) {
         self.node.unmount()
@@ -121,12 +121,12 @@ where
         true
     }
 }
-pub struct StringState<R: Renderer> {
+pub struct StringState<R: StringRenderer> {
     node: R::Text,
     str: String,
 }
 
-impl<R: Renderer> Render<R> for String {
+impl<R: StringRenderer> Render<R> for String {
     type State = StringState<R>;
 
     fn build(self) -> Self::State {
@@ -147,7 +147,7 @@ impl InfallibleRender for String {}
 
 impl<R> RenderHtml<R> for String
 where
-    R: Renderer,
+    R: StringRenderer,
     R::Node: Clone,
     R::Element: Clone,
 {
@@ -184,7 +184,7 @@ impl ToTemplate for String {
     }
 }
 
-impl<R: Renderer> Mountable<R> for StringState<R> {
+impl<R: StringRenderer> Mountable<R> for StringState<R> {
     fn unmount(&mut self) {
         self.node.unmount()
     }
@@ -207,12 +207,12 @@ impl<R: Renderer> Mountable<R> for StringState<R> {
     }
 }
 
-pub struct RcStrState<R: Renderer> {
+pub struct RcStrState<R: StringRenderer> {
     node: R::Text,
     str: Rc<str>,
 }
 
-impl<R: Renderer> Render<R> for Rc<str> {
+impl<R: StringRenderer> Render<R> for Rc<str> {
     type State = RcStrState<R>;
 
     fn build(self) -> Self::State {
@@ -233,7 +233,7 @@ impl InfallibleRender for Rc<str> {}
 
 impl<R> RenderHtml<R> for Rc<str>
 where
-    R: Renderer,
+    R: StringRenderer,
     R::Node: Clone,
     R::Element: Clone,
 {
@@ -271,7 +271,7 @@ impl ToTemplate for Rc<str> {
     }
 }
 
-impl<R: Renderer> Mountable<R> for RcStrState<R> {
+impl<R: StringRenderer> Mountable<R> for RcStrState<R> {
     fn unmount(&mut self) {
         self.node.unmount()
     }
@@ -294,12 +294,12 @@ impl<R: Renderer> Mountable<R> for RcStrState<R> {
     }
 }
 
-pub struct ArcStrState<R: Renderer> {
+pub struct ArcStrState<R: StringRenderer> {
     node: R::Text,
     str: Arc<str>,
 }
 
-impl<R: Renderer> Render<R> for Arc<str> {
+impl<R: StringRenderer> Render<R> for Arc<str> {
     type State = ArcStrState<R>;
 
     fn build(self) -> Self::State {
@@ -320,7 +320,7 @@ impl InfallibleRender for Arc<str> {}
 
 impl<R> RenderHtml<R> for Arc<str>
 where
-    R: Renderer,
+    R: StringRenderer,
     R::Node: Clone,
     R::Element: Clone,
 {
@@ -358,7 +358,7 @@ impl ToTemplate for Arc<str> {
     }
 }
 
-impl<R: Renderer> Mountable<R> for ArcStrState<R> {
+impl<R: StringRenderer> Mountable<R> for ArcStrState<R> {
     fn unmount(&mut self) {
         self.node.unmount()
     }


### PR DESCRIPTION
This enables renderers like `bevy_ui` where plain text nodes without styling are discouraged, and a `Text` widget should be used instead. It prevents rendering plain strings unless `StringRenderer` is also implemented for that renderer.